### PR TITLE
[16.0][IMP] edi_oca: after max retries attempts, explicitly set records as KO

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -345,11 +345,20 @@ class EDIBackend(models.Model):
             exceptions.ValidationError,
         )
 
-    def _send_retryable_exceptions(self):
+    def _common_retryable_exceptions(self):
         # IOError is a base class for all connection errors
         # OSError is a base class for all errors
         # when dealing w/ internal or external systems or filesystems
         return (IOError, OSError)
+
+    def _receive_retryable_exceptions(self):
+        return self._common_retryable_exceptions()
+
+    def _process_retryable_exceptions(self):
+        return self._common_retryable_exceptions()
+
+    def _send_retryable_exceptions(self):
+        return self._common_retryable_exceptions()
 
     def _output_check_send(self, exchange_record):
         if exchange_record.direction != "output":
@@ -493,6 +502,14 @@ class EDIBackend(models.Model):
             error = _get_exception_msg()
             state = "input_processed_error"
             res = f"Error: {error}"
+        except self._process_retryable_exceptions() as err:
+            error = _get_exception_msg()
+            _logger.debug(
+                "%s process failed. To be retried.", exchange_record.identifier
+            )
+            raise RetryableJobError(
+                error, **exchange_record._job_retry_params()
+            ) from err
         else:
             error = None
             state = "input_processed"
@@ -551,6 +568,14 @@ class EDIBackend(models.Model):
             state = "input_receive_error"
             message = exchange_record._exchange_status_message("receive_ko")
             res = f"Input error: {error}"
+        except self._receive_retryable_exceptions() as err:
+            error = _get_exception_msg()
+            _logger.debug(
+                "%s receive failed. To be retried.", exchange_record.identifier
+            )
+            raise RetryableJobError(
+                error, **exchange_record._job_retry_params()
+            ) from err
         else:
             message = exchange_record._exchange_status_message("receive_ok")
             error = None

--- a/edi_oca/tests/test_backend_jobs.py
+++ b/edi_oca/tests/test_backend_jobs.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from requests.exceptions import ConnectionError as ReqConnectionError
 
-from odoo.addons.queue_job.exception import RetryableJobError
+from odoo.addons.queue_job.exception import FailedJobError, RetryableJobError
 from odoo.addons.queue_job.tests.common import JobMixin
 
 from .common import EDIBackendCommonTestCase
@@ -66,6 +66,31 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
             with self.assertRaises(RetryableJobError):
                 job.perform()
 
+    def test_output_failed_record_on_max_retries_reached(self):
+        job_counter = self.job_counter()
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+            "edi_exchange_state": "output_pending",
+        }
+        record = self.backend.create_record("test_csv_output", vals)
+        record._set_file_content("ABC")
+        job = record.with_delay().action_exchange_send()
+        job_counter.search_created()
+        with mock.patch.object(type(self.backend), "_exchange_send") as mocked_1:
+            mocked_1.side_effect = ReqConnectionError("Connection broken")
+            job.exc_info = "Traceback of error:......"
+            job.max_retries = 1
+            # Job will be failed
+            with self.assertRaises(FailedJobError):
+                job.perform()
+            # But we want to check the record
+            try:
+                job.perform()
+            except FailedJobError:
+                self.assertEqual(record.edi_exchange_state, "output_error_on_send")
+                self.assertEqual(record.exchange_error, job.exc_info)
+
     def test_input(self):
         job_counter = self.job_counter()
         vals = {
@@ -95,3 +120,46 @@ class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
         job = self.backend.with_delay().exchange_process(record)
         created = job_counter.search_created()
         self.assertEqual(created[0].name, "Process an incoming document.")
+
+    def test_input_failed_record_on_max_retries_reached(self):
+        # Test with receive exchange
+        job_counter = self.job_counter()
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+            "edi_exchange_state": "input_pending",
+        }
+        record = self.backend.create_record("test_csv_input", vals)
+        job = record.with_delay().action_exchange_receive()
+        job_counter.search_created()
+        with mock.patch.object(type(self.backend), "_exchange_receive") as mocked_1:
+            mocked_1.side_effect = ReqConnectionError("Connection broken")
+            job.exc_info = "Traceback of error:......receive error"
+            job.max_retries = 1
+            # Job will be failed
+            with self.assertRaises(FailedJobError):
+                job.perform()
+            # But we want to check the record
+            try:
+                job.perform()
+            except FailedJobError:
+                self.assertEqual(record.edi_exchange_state, "input_receive_error")
+                self.assertEqual(record.exchange_error, job.exc_info)
+        # Test with process exchange
+        record.edi_exchange_state = "input_received"
+        record._set_file_content("ABC")
+        job = record.with_delay().action_exchange_process()
+        job_counter.search_created()
+        with mock.patch.object(type(self.backend), "_exchange_process") as mocked_1:
+            mocked_1.side_effect = ReqConnectionError("Connection broken")
+            job.exc_info = "Traceback of error:......process error"
+            job.max_retries = 1
+            # Job will be failed
+            with self.assertRaises(FailedJobError):
+                job.perform()
+            # But we want to check the record
+            try:
+                job.perform()
+            except FailedJobError:
+                self.assertEqual(record.edi_exchange_state, "input_processed_error")
+                self.assertEqual(record.exchange_error, job.exc_info)


### PR DESCRIPTION
Depend on:
- https://github.com/QuocDuong1306/queue/pull/2

When a non-final error occurs, the exception is raised (e.g. OSError), for `Receive` exchange:

- The job fails

- The record state stays as "input_pending"

- Another action_exchange_receive Job will be created next time scheduled action "EDI exchange check input sync" runs, to try again to receive it, hopefully successfully this time

We want to change it to rely more on the RetryableJobError mechanism than on the "EDI exchange check input sync" scheduled action